### PR TITLE
Ignore non-matched groups when replacing with sub

### DIFF
--- a/src/match.pxi
+++ b/src/match.pxi
@@ -171,9 +171,8 @@ cdef class Match:
                     n += 1
                 if groupno <= self.re.groups:
                     groupval = self._group(groupno)
-                    if groupval is None:
-                        raise RegexError('unmatched group')
-                    result.extend(groupval)
+                    if groupval is not None:
+                        result.extend(groupval)
                 else:
                     raise RegexError('invalid group reference.')
             elif cstring[n] == b'g':  # named group reference
@@ -197,9 +196,8 @@ cdef class Match:
                     if self.encoded:
                         name = name.decode('utf8')
                 groupval = self._group(name)
-                if groupval is None:
-                    raise RegexError('unmatched group')
-                result.extend(groupval)
+                if groupval is not None:
+                    result.extend(groupval)
                 n += 1
             else:
                 if cstring[n] == b'n':


### PR DESCRIPTION
From 3.5 onwards sub() and subn() now replace unmatched groups with empty strings. See:

https://docs.python.org/3/whatsnew/3.5.html#re

This change removes the 'unmatched group' error which occurs when using re2.