### PR TITLE
macports support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ else:
 
 
 # Locate the re2 module
-_re2_prefixes = ['/usr', '/usr/local', '/opt/', os.environ['HOME'] + '/.local']
+_re2_prefixes = ['/usr', '/usr/local', '/opt/', '/opt/local', os.environ['HOME'] + '/.local']
 
 re2_prefix = ''
 for a in _re2_prefixes:


### PR DESCRIPTION
Hi. 

(upstream repository is maybe abadnoned, so sending PR to your repository)

I'm using Macports on MacOS, and Macports storing re2 library's position is unexpected directory.

```console
$ port contents re2 | grep stringpiece
  /opt/local/include/re2/stringpiece.h
```

So, installing pyre2 via your repository is failed.

```
$ pip install "git+git://github.com/andreasvc/pyre2.git@master"
...
    src/re2.cpp:312:10: fatal error: 're2/stringpiece.h' file not found
    #include "re2/stringpiece.h"
             ^
    1 error generated.
    error: command '/usr/bin/clang' failed with exit status 1
```

So, Adding `/opt/local`  path to `_re2_prefixes`.