### PR TITLE
Adding c++ 11 compile flag on Ubuntu

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,15 @@ import io
 import os
 import re
 import sys
+import platform
 from distutils.core import setup, Extension, Command
 
 MINIMUM_CYTHON_VERSION = '0.20'
 BASE_DIR = os.path.dirname(__file__)
 PY2 = sys.version_info[0] == 2
 DEBUG = False
+
+FLAG_PLATFORMS = ["ubuntu"]
 
 # kludge; http://stackoverflow.com/a/37762853
 try:
@@ -75,6 +78,24 @@ def get_authors():
     authors_f.close()
     return ', '.join(authors)
 
+def flag_platform():
+    # Some platforms require the `-std=c++11` flag. These are the platforms:
+    try:
+        return platform.linux_distribution()[0].lower() in FLAG_PLATFORMS
+    except:
+        return False
+
+def add_cpp_flag():
+    # We add `-std=c++11` as a compiler flag in the following cases:
+    # 1. If the compiler is CLANG
+    # 2. If the platform requires the flag for compilaton
+
+    if CLANG:
+        return True
+    if flag_platform():
+        return True
+    return False
+
 def main():
     os.environ['GCC_COLORS'] = 'auto'
     include_dirs = [os.path.join(re2_prefix, 'include')] if re2_prefix else []
@@ -84,7 +105,7 @@ def main():
             ] if re2_prefix else []
     extra_compile_args = ['-O0', '-g'] if DEBUG else [
             '-O3', '-march=native', '-DNDEBUG']
-    if CLANG:
+    if add_cpp_flag():
         extra_compile_args.append('-std=c++11')
     ext_modules = [
         Extension(


### PR DESCRIPTION
This pull replaces the check
```
if CLAG:
   extra_compile_args.append('-std=c++11')
```
with this check:
```
if add_cpp_flag():
    extra_compile_args.append('-std=c++11')
```

The function `add_cpp_flag` checks weather or not the compiler is CLANG and the platform. If the platform is in a list of platforms that require this flag ( only `Ubuntu` at the moment ), than we also add the `-std=c++11` flag.

I haven't tested this very well. Please, let me know if there are any issues with this.