### PR TITLE
workaroud for manylinux dependency install error plus release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,19 @@
-name: Build
+name: Release
 
-on: [push, pull_request]
+on:
+  push:
+    # release on tag push
+    tags:
+      - '*'
 
 jobs:
-  build_wheels:
+  create_wheels:
     name: Build wheels on ${{ matrix.os }} for Python
     runs-on: ${{ matrix.os }}
     env:
       MANYLINUX2010_X86_64_TAG: "2020-12-03-912b0de"
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-latest]
 
@@ -23,12 +28,10 @@ jobs:
       - name: Install cibuildwheel
         run: |
           python -m pip install cibuildwheel==1.7.1
-
       - name: Install Visual C++ for Python 2.7
         if: runner.os == 'Windows'
         run: |
           choco install vcpython27 -f -y
-
       - name: Build wheels
         env:
           CIBW_BEFORE_ALL_LINUX: >
@@ -38,46 +41,54 @@ jobs:
           CIBW_BUILD: cp36-* cp37-* cp38-*
         run: |
           python -m cibuildwheel --output-dir wheelhouse
-
       - uses: actions/upload-artifact@v2
         with:
+          name: wheels
           path: ./wheelhouse/*.whl
 
-  build_sdist:
-    name: Build source distribution
-    runs-on: ubuntu-latest
+  create_release:
+    name: Create Release
+    needs: [create_wheels]
+    runs-on: ubuntu-20.04
+
     steps:
+      - name: Get version
+        id: get_version
+        run: |
+          echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+          echo ${{ env.VERSION }}
+
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: 3.7
 
-      - name: Build sdist
-        run: |
-          pip install --user cython
-          python setup.py sdist
-
-      - uses: actions/upload-artifact@v2
-        with:
-          path: dist/*.tar.gz
-
-  upload_pypi:
-    needs: [build_wheels, build_sdist]
-    runs-on: ubuntu-latest
-    # upload to PyPI on every tag starting with 'v'
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
-    # alternatively, to publish when a GitHub Release is created, use the following rule:
-    # if: github.event_name == 'release' && github.event.action == 'published'
-    steps:
       - uses: actions/download-artifact@v2
         with:
-          name: artifact
-          path: dist
+          name: wheels
 
-      - uses: pypa/gh-action-pypi-publish@master
+      - name: Install gitchangelog
+        run: |
+          pip install git+https://github.com/freepn/gitchangelog@3.0.4-4
+
+      - name: Generate changes file
+        run: |
+          bash -c 'cat $(get-rcpath) > .gitchangelog.rc'
+          bash -c 'gitchangelog $(git tag -l | tail -n2 | head -n1)..${{ env.VERSION }} > CHANGES.md'
+
+      - name: Create draft release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
-
+          tag_name: ${{ env.VERSION }}
+          name: Release v${{ env.VERSION }}
+          body_path: CHANGES.md
+          draft: false
+          prerelease: false
+          files: ./pyre2*.whl


### PR DESCRIPTION
This is *almost* everything I have in my github actions so far, and includes the manylinux yum fixes.  I also added a basic release flow (since I just got that working) with the following features:

* *only* runs on tag push
* builds wheels again (required for artifacts in the release)
* uses gitchangelog to populate the release notes
* uploads built wheels to the release

There are lots of ways to customize the output of gitchangelog; the default github.release.rc file is just a compact markdown output so the release page doesn't get too huge.  Lemme know if you don't want that part and I'll remove it from the PR.