### PR TITLE
Workflow cleanup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,21 +82,3 @@ jobs:
         with:
           path: dist/*.tar.gz
 
-  upload_pypi:
-    needs: [build_wheels, build_sdist]
-    runs-on: ubuntu-latest
-    # upload to PyPI on every tag starting with 'v'
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
-    # alternatively, to publish when a GitHub Release is created, use the following rule:
-    # if: github.event_name == 'release' && github.event.action == 'published'
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: artifact
-          path: dist
-
-      - uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,15 +84,13 @@ jobs:
 
       # download all artifacts to project dir
       - uses: actions/download-artifact@v2
-
-      - name: Install gitchangelog
-        run: |
-          pip install git+https://github.com/freepn/gitchangelog@3.0.5#egg=gitchangelog
+        with:
+          path: dist
 
       - name: Generate changes file
-        run: |
-          export GITCHANGELOG_CONFIG_FILENAME=$(get-rcpath)
-          gitchangelog $(git describe --abbrev=0 ${{ env.VERSION }})..${{ env.VERSION }} > CHANGES.md
+        uses: sarnold/gitchangelog-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN}}
 
       - name: Create draft release
         id: create_release
@@ -103,7 +101,13 @@ jobs:
           tag_name: ${{ env.VERSION }}
           name: Release v${{ env.VERSION }}
           body_path: CHANGES.md
-          draft: true
-          prerelease: true
+          draft: false
+          prerelease: false
           # uncomment below to upload wheels to github releases
-          # files: wheels/pyre2*.whl
+          files: dist/cibw-wheels/pyre2*.whl
+
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}
+          packages_dir: dist/cibw-wheels/


### PR DESCRIPTION
* move pypi upload to end of release.yml
* use gitchangelog action

Check the current github release flags and modify as needed, or leave a review comment and I'll push the changes:

```
          draft: false
          prerelease: false
          # uncomment below to upload wheels to github releases
          files: dist/cibw-wheels/pyre2*.whl
```
