### PR TITLE
Add support for python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04]
-        python-version: [3.9, '3.10', '3.11', '3.12']
+        python-version: [3.9, '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/conda-dev.yml
+++ b/.github/workflows/conda-dev.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-22.04', 'macos-13']
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
           CIBW_TEST_SKIP: "*_arm64 *universal2:arm64 *linux_i686"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_I686_IMAGE: manylinux2010
-          CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
+          CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*
           CIBW_SKIP: "*musllinux* *i686"
           CIBW_BEFORE_ALL_LINUX: >
             yum -y update && yum -y install epel-release && yum install -y re2-devel ninja-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           CIBW_TEST_SKIP: "*_arm64 *universal2:arm64 *linux_i686"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_I686_IMAGE: manylinux2010
-          CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
+          CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*
           CIBW_SKIP: "*musllinux* *i686"
           CIBW_BEFORE_ALL_LINUX: >
             yum -y update && yum -y install epel-release && yum install -y re2-devel ninja-build

--- a/src/includes.pxi
+++ b/src/includes.pxi
@@ -12,11 +12,6 @@ cdef extern from *:
     cdef void emit_endif "#endif //" ()
 
 
-cdef extern from "Python.h":
-    int PyObject_CheckReadBuffer(object)
-    int PyObject_AsReadBuffer(object, const void **, Py_ssize_t *)
-
-
 cdef extern from "re2/stringpiece.h" namespace "re2":
     cdef cppclass StringPiece:
         StringPiece()

--- a/src/re2.pyx
+++ b/src/re2.pyx
@@ -366,14 +366,7 @@ cdef inline int pystring_to_cstring(
     cdef int result = -1
     cstring[0] = NULL
     size[0] = 0
-    if PY2:
-        # Although the new-style buffer interface was backported to Python 2.6,
-        # some modules, notably mmap, only support the old buffer interface.
-        # Cf. http://bugs.python.org/issue9229
-        if PyObject_CheckReadBuffer(pystring) == 1:
-            result = PyObject_AsReadBuffer(
-                    pystring, <const void **>cstring, size)
-    elif PyObject_CheckBuffer(pystring) == 1:  # new-style Buffer interface
+    if PyObject_CheckBuffer(pystring) == 1:  # new-style Buffer interface
         result = PyObject_GetBuffer(pystring, buf, PyBUF_SIMPLE)
         if result == 0:
             cstring[0] = <char *>buf.buf

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{7,8,9,10,11,12}
+envlist = py3{7,8,9,10,11,12,13}
 skip_missing_interpreters = true
 isolated_build = true
 skipsdist=True
@@ -12,6 +12,7 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [gh-actions:env]
 PLATFORM =


### PR DESCRIPTION
## Summary
- Added support for Python 3.13.
- Removed deprecated methods that were only used for Python 2, which has already been deprecated in this project.

## Breaking change?
- This project no longer supports Python 2