### PR TITLE
Fix `FallbackPattern.__reduce__`

### DIFF
--- a/src/pattern.pxi
+++ b/src/pattern.pxi
@@ -647,4 +647,4 @@ class FallbackPattern:
         return repr(self._pattern)
 
     def __reduce__(self):
-        return (self, (self.pattern, self.flags))
+        return (self.__class__, (self.pattern, self.flags))


### PR DESCRIPTION
`FallbackPattern` is currently not picklable due to an incorrect `__reduce__` method, which this PR fixes.