### PR TITLE
fix: use an LRU cache for cached patterns

### DIFF
--- a/src/compile.pxi
+++ b/src/compile.pxi
@@ -1,13 +1,15 @@
 
 def compile(pattern, int flags=0, int max_mem=8388608):
     cachekey = (type(pattern), pattern, flags, current_notification)
-    if cachekey in _cache:
-        return _cache[cachekey]
-    p = _compile(pattern, flags, max_mem)
+    try:
+        p = _cache[cachekey]
+        _cache.move_to_end(cachekey)
+    except KeyError:
+        p = _compile(pattern, flags, max_mem)
 
-    if len(_cache) >= _MAXCACHE:
-        _cache.popitem()
-    _cache[cachekey] = p
+        if len(_cache) >= _MAXCACHE:
+            _cache.popitem(last=False)
+        _cache[cachekey] = p
     return p
 
 

--- a/src/re2.pyx
+++ b/src/re2.pyx
@@ -110,6 +110,7 @@ import sys
 import types
 import warnings
 from re import error as RegexError
+from collections import OrderedDict
 
 error = re.error
 
@@ -157,8 +158,8 @@ cdef int current_notification = FALLBACK_QUIETLY
 # Type of compiled re object from Python stdlib
 SREPattern = type(re.compile(''))
 
-_cache = {}
-_cache_repl = {}
+_cache = OrderedDict()
+_cache_repl = OrderedDict()
 
 _MAXCACHE = 100
 

--- a/tests/test_re.py
+++ b/tests/test_re.py
@@ -813,3 +813,43 @@ def test_re_suite():
                 result = obj.search(s)
                 if result is None:
                     print('=== Fails on unicode-sensitive match', t)
+
+
+class LRUCacheTests(unittest.TestCase):
+    """Tests for the LRU eviction semantics of the pattern cache."""
+
+    def setUp(self):
+        re.purge()
+
+    def tearDown(self):
+        re.purge()
+
+    def test_cache_hit_returns_same_object(self):
+        """Compiling the same pattern twice returns the cached instance."""
+        p1 = re.compile(r'\d+')
+        p2 = re.compile(r'\d+')
+        self.assertIs(p1, p2)
+
+    def test_lru_eviction_keeps_recently_used(self):
+        """A pattern used after other patterns are inserted survives eviction."""
+        import re2 as _re2
+
+        original_max = _re2._MAXCACHE
+        try:
+            _re2._MAXCACHE = 3
+
+            re.compile(r'a')  # slot 1
+            re.compile(r'b')  # slot 2
+            re.compile(r'c')  # slot 3 — cache full
+
+            # Access 'a' to make it MRU; 'b' is now LRU.
+            re.compile(r'a')
+
+            # Insert a new pattern — 'b' (LRU) must be evicted, not 'a'.
+            re.compile(r'd')
+
+            # 'a' must still be cached (was MRU); 'b' must have been evicted.
+            self.assertIn((str, r'a', 0, _re2.FALLBACK_QUIETLY), _re2._cache)
+            self.assertNotIn((str, r'b', 0, _re2.FALLBACK_QUIETLY), _re2._cache)
+        finally:
+            _re2._MAXCACHE = original_max


### PR DESCRIPTION
# Description

Previously cache used was a LIFO cache: when cache size were > `_MAXCACHE`, we used `_cache.popitem()` that removes the 1st element of the cache and then `_cache[cachekey] = p` to add element to cache, that add the item to the top of the cache.

This PR introduces `OrderedDict` for cache management and changes LIFO behaviour to LRU.

Closes https://github.com/andreasvc/pyre2/issues/59